### PR TITLE
ECSW-2087: Fix plugin url and omit hash in version string

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ VERSION_PATH     := ${PROVIDER_PATH}/pkg/version.Version
 
 TFGEN           := pulumi-tfgen-${PACK}
 PROVIDER        := pulumi-resource-${PACK}
-VERSION         := $(shell pulumictl get version)
+VERSION         := $(shell pulumictl get version --omit-commit-hash)
 
 TESTPARALLELISM := 4
 
@@ -57,7 +57,7 @@ provider:: tfgen install_plugins # build the provider binary
 
 build_sdks:: install_plugins provider build_nodejs build_python build_go build_dotnet # build all the sdks
 
-build_nodejs:: VERSION := $(shell pulumictl get version --language javascript)
+build_nodejs:: VERSION := $(shell pulumictl get version --omit-commit-hash --language javascript)
 build_nodejs:: install_plugins tfgen # build the node sdk
 	$(WORKING_DIR)/bin/$(TFGEN) nodejs --overlays provider/overlays/nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
@@ -66,7 +66,7 @@ build_nodejs:: install_plugins tfgen # build the node sdk
         cp ../../README.md ../../LICENSE package.json yarn.lock ./bin/ && \
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 
-build_python:: PYPI_VERSION := $(shell pulumictl get version --language python)
+build_python:: PYPI_VERSION := $(shell pulumictl get version --omit-commit-hash --language python)
 build_python:: install_plugins tfgen # build the python sdk
 	$(WORKING_DIR)/bin/$(TFGEN) python --overlays provider/overlays/python --out sdk/python/
 	cd sdk/python/ && \
@@ -77,9 +77,9 @@ build_python:: install_plugins tfgen # build the python sdk
         rm ./bin/setup.py.bak && \
         cd ./bin && python3 setup.py build sdist
 
-build_dotnet:: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
+build_dotnet:: DOTNET_VERSION := $(shell pulumictl get version --omit-commit-hash --language dotnet)
 build_dotnet:: install_plugins tfgen # build the dotnet sdk
-	pulumictl get version --language dotnet
+	pulumictl get version --omit-commit-hash --language dotnet
 	$(WORKING_DIR)/bin/$(TFGEN) dotnet --overlays provider/overlays/dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
 		echo "${DOTNET_VERSION}" >version.txt && \

--- a/provider/cmd/pulumi-resource-stackpath/schema.json
+++ b/provider/cmd/pulumi-resource-stackpath/schema.json
@@ -12,7 +12,7 @@
     "attribution": "This Pulumi package is based on the [`stackpath` Terraform Provider](https://github.com/stackpath/terraform-provider-stackpath).",
     "repository": "https://github.com/stackpath/pulumi-stackpath",
     "logoUrl": "https://raw.githubusercontent.com/stackpath/pulumi-stackpath/main/assets/logo.svg",
-    "pluginDownloadURL": "https://github.com/stackpath/pulumi-stackpath/releases/download/v${VERSION}",
+    "pluginDownloadURL": "github://api.github.com/stackpath/pulumi-stackpath",
     "publisher": "StackPath",
     "meta": {
         "moduleFormat": "(.*)(?:/[^/]*)"

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -68,7 +68,7 @@ func Provider() tfbridge.ProviderInfo {
 		// PluginDownloadURL is an optional URL used to download the Provider
 		// for use in Pulumi programs
 		// e.g https://github.com/org/pulumi-provider-name/releases/
-		PluginDownloadURL: "https://github.com/stackpath/pulumi-stackpath/releases/download/v${VERSION}",
+		PluginDownloadURL: "github://api.github.com/stackpath/pulumi-stackpath",
 		Description:       "A Pulumi package for creating and managing stackpath cloud resources.",
 		// category/cloud tag helps with categorizing the package in the Pulumi Registry.
 		// For all available categories, see `Keywords` in

--- a/sdk/dotnet/Compute/Network.cs
+++ b/sdk/dotnet/Compute/Network.cs
@@ -63,7 +63,7 @@ namespace Stackpath.Stackpath.Compute
             var defaultOptions = new CustomResourceOptions
             {
                 Version = Utilities.Version,
-                PluginDownloadURL = "https://github.com/stackpath/pulumi-stackpath/releases/download/v${VERSION}",
+                PluginDownloadURL = "github://api.github.com/stackpath/pulumi-stackpath",
             };
             var merged = CustomResourceOptions.Merge(defaultOptions, options);
             // Override the ID if one was specified for consistency with other language SDKs.

--- a/sdk/dotnet/Compute/NetworkPolicy.cs
+++ b/sdk/dotnet/Compute/NetworkPolicy.cs
@@ -72,7 +72,7 @@ namespace Stackpath.Stackpath.Compute
             var defaultOptions = new CustomResourceOptions
             {
                 Version = Utilities.Version,
-                PluginDownloadURL = "https://github.com/stackpath/pulumi-stackpath/releases/download/v${VERSION}",
+                PluginDownloadURL = "github://api.github.com/stackpath/pulumi-stackpath",
             };
             var merged = CustomResourceOptions.Merge(defaultOptions, options);
             // Override the ID if one was specified for consistency with other language SDKs.

--- a/sdk/dotnet/Compute/NetworkRoute.cs
+++ b/sdk/dotnet/Compute/NetworkRoute.cs
@@ -60,7 +60,7 @@ namespace Stackpath.Stackpath.Compute
             var defaultOptions = new CustomResourceOptions
             {
                 Version = Utilities.Version,
-                PluginDownloadURL = "https://github.com/stackpath/pulumi-stackpath/releases/download/v${VERSION}",
+                PluginDownloadURL = "github://api.github.com/stackpath/pulumi-stackpath",
             };
             var merged = CustomResourceOptions.Merge(defaultOptions, options);
             // Override the ID if one was specified for consistency with other language SDKs.

--- a/sdk/dotnet/Compute/NetworkSubnet.cs
+++ b/sdk/dotnet/Compute/NetworkSubnet.cs
@@ -57,7 +57,7 @@ namespace Stackpath.Stackpath.Compute
             var defaultOptions = new CustomResourceOptions
             {
                 Version = Utilities.Version,
-                PluginDownloadURL = "https://github.com/stackpath/pulumi-stackpath/releases/download/v${VERSION}",
+                PluginDownloadURL = "github://api.github.com/stackpath/pulumi-stackpath",
             };
             var merged = CustomResourceOptions.Merge(defaultOptions, options);
             // Override the ID if one was specified for consistency with other language SDKs.

--- a/sdk/dotnet/Compute/Workload.cs
+++ b/sdk/dotnet/Compute/Workload.cs
@@ -78,7 +78,7 @@ namespace Stackpath.Stackpath.Compute
             var defaultOptions = new CustomResourceOptions
             {
                 Version = Utilities.Version,
-                PluginDownloadURL = "https://github.com/stackpath/pulumi-stackpath/releases/download/v${VERSION}",
+                PluginDownloadURL = "github://api.github.com/stackpath/pulumi-stackpath",
             };
             var merged = CustomResourceOptions.Merge(defaultOptions, options);
             // Override the ID if one was specified for consistency with other language SDKs.

--- a/sdk/dotnet/Provider.cs
+++ b/sdk/dotnet/Provider.cs
@@ -52,7 +52,7 @@ namespace Stackpath.Stackpath
             var defaultOptions = new CustomResourceOptions
             {
                 Version = Utilities.Version,
-                PluginDownloadURL = "https://github.com/stackpath/pulumi-stackpath/releases/download/v${VERSION}",
+                PluginDownloadURL = "github://api.github.com/stackpath/pulumi-stackpath",
                 AdditionalSecretOutputs =
                 {
                     "accessToken",

--- a/sdk/dotnet/Storage/Bucket.cs
+++ b/sdk/dotnet/Storage/Bucket.cs
@@ -48,7 +48,7 @@ namespace Stackpath.Stackpath.Storage
             var defaultOptions = new CustomResourceOptions
             {
                 Version = Utilities.Version,
-                PluginDownloadURL = "https://github.com/stackpath/pulumi-stackpath/releases/download/v${VERSION}",
+                PluginDownloadURL = "github://api.github.com/stackpath/pulumi-stackpath",
             };
             var merged = CustomResourceOptions.Merge(defaultOptions, options);
             // Override the ID if one was specified for consistency with other language SDKs.

--- a/sdk/dotnet/Utilities.cs
+++ b/sdk/dotnet/Utilities.cs
@@ -53,7 +53,7 @@ namespace Stackpath.Stackpath
         {
             var dst = src ?? new global::Pulumi.InvokeOptions{};
             dst.Version = src?.Version ?? Version;
-            dst.PluginDownloadURL = src?.PluginDownloadURL ?? "https://github.com/stackpath/pulumi-stackpath/releases/download/v${VERSION}";
+            dst.PluginDownloadURL = src?.PluginDownloadURL ?? "github://api.github.com/stackpath/pulumi-stackpath";
             return dst;
         }
 

--- a/sdk/dotnet/pulumi-plugin.json
+++ b/sdk/dotnet/pulumi-plugin.json
@@ -1,5 +1,5 @@
 {
   "resource": true,
   "name": "stackpath",
-  "server": "https://github.com/stackpath/pulumi-stackpath/releases/download/v${VERSION}"
+  "server": "github://api.github.com/stackpath/pulumi-stackpath"
 }

--- a/sdk/go/stackpath/internal/pulumiUtilities.go
+++ b/sdk/go/stackpath/internal/pulumiUtilities.go
@@ -164,7 +164,7 @@ func callPlainInner(
 // PkgResourceDefaultOpts provides package level defaults to pulumi.OptionResource.
 func PkgResourceDefaultOpts(opts []pulumi.ResourceOption) []pulumi.ResourceOption {
 	defaults := []pulumi.ResourceOption{}
-	defaults = append(defaults, pulumi.PluginDownloadURL("https://github.com/stackpath/pulumi-stackpath/releases/download/v${VERSION}"))
+	defaults = append(defaults, pulumi.PluginDownloadURL("github://api.github.com/stackpath/pulumi-stackpath"))
 	version := SdkVersion
 	if !version.Equals(semver.Version{}) {
 		defaults = append(defaults, pulumi.Version(version.String()))
@@ -175,7 +175,7 @@ func PkgResourceDefaultOpts(opts []pulumi.ResourceOption) []pulumi.ResourceOptio
 // PkgInvokeDefaultOpts provides package level defaults to pulumi.OptionInvoke.
 func PkgInvokeDefaultOpts(opts []pulumi.InvokeOption) []pulumi.InvokeOption {
 	defaults := []pulumi.InvokeOption{}
-	defaults = append(defaults, pulumi.PluginDownloadURL("https://github.com/stackpath/pulumi-stackpath/releases/download/v${VERSION}"))
+	defaults = append(defaults, pulumi.PluginDownloadURL("github://api.github.com/stackpath/pulumi-stackpath"))
 	version := SdkVersion
 	if !version.Equals(semver.Version{}) {
 		defaults = append(defaults, pulumi.Version(version.String()))

--- a/sdk/go/stackpath/pulumi-plugin.json
+++ b/sdk/go/stackpath/pulumi-plugin.json
@@ -1,5 +1,5 @@
 {
   "resource": true,
   "name": "stackpath",
-  "server": "https://github.com/stackpath/pulumi-stackpath/releases/download/v${VERSION}"
+  "server": "github://api.github.com/stackpath/pulumi-stackpath"
 }

--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -24,6 +24,6 @@
     "pulumi": {
         "resource": true,
         "name": "stackpath",
-        "server": "https://github.com/stackpath/pulumi-stackpath/releases/download/v${VERSION}"
+        "server": "github://api.github.com/stackpath/pulumi-stackpath"
     }
 }

--- a/sdk/nodejs/utilities.ts
+++ b/sdk/nodejs/utilities.ts
@@ -53,7 +53,7 @@ export function getVersion(): string {
 
 /** @internal */
 export function resourceOptsDefaults(): any {
-    return { version: getVersion(), pluginDownloadURL: "https://github.com/stackpath/pulumi-stackpath/releases/download/v${VERSION}" };
+    return { version: getVersion(), pluginDownloadURL: "github://api.github.com/stackpath/pulumi-stackpath" };
 }
 
 /** @internal */

--- a/sdk/python/pulumi_stackpath/_utilities.py
+++ b/sdk/python/pulumi_stackpath/_utilities.py
@@ -288,4 +288,4 @@ async def _await_output(o: pulumi.Output[typing.Any]) -> typing.Tuple[object, bo
     )
 
 def get_plugin_download_url():
-	return "https://github.com/stackpath/pulumi-stackpath/releases/download/v${VERSION}"
+	return "github://api.github.com/stackpath/pulumi-stackpath"

--- a/sdk/python/pulumi_stackpath/pulumi-plugin.json
+++ b/sdk/python/pulumi_stackpath/pulumi-plugin.json
@@ -1,5 +1,5 @@
 {
   "resource": true,
   "name": "stackpath",
-  "server": "https://github.com/stackpath/pulumi-stackpath/releases/download/v${VERSION}"
+  "server": "github://api.github.com/stackpath/pulumi-stackpath"
 }


### PR DESCRIPTION
## Description

Fixes version mismatch

Pulumi couldn't automatically pull the provider binary due to version mismatch:
Makefile uses `pulumictl` to retrieve version
```sh
# before this change:  0.0.1-alpha.10+71704ab6
pulumictl get version
# after this change: 0.0.1-alpha.10
pulumictl get version --omit-commit-hash 
```

But `goreleaser` uses {{ .Tag }}, which results in: `0.0.1-alpha.10`

`pulumi up` output (after fix):

```sh
pulumi up -s dev 
Previewing update (dev)

View in Browser (Ctrl+O): https://app.pulumi.com/nebojsa-koturovic-stackpath-com/example/dev/previews/530858bd-1ecd-4cfc-98a0-d7d71b22c2d1

Downloading plugin: 19.36 MiB / 19.36 MiB [=========================] 100.00% 5s
                                                                                [resource plugin stackpath-0.0.1-alpha.10] installing
     Type                           Name                  Plan       Info
 +   pulumi:pulumi:Stack            example-dev               create 
 +   └─ stackpath:compute:Workload  my-compute-workload1  create     
 +   └─ stackpath:compute:Workload  my-compute-workload1  create     

Resources:
    + 2 to create

Do you want to perform this update? yes
Updating (dev)

View in Browser (Ctrl+O): https://app.pulumi.com/nebojsa-koturovic-stackpath-com/lnn/dev/updates/1

     Type                           Name                  Status           
 +   pulumi:pulumi:Stack            lnn-dev               created (1s)     
 +   └─ stackpath:compute:Workload  my-compute-workload1  created (2s)     

Resources:
    + 2 created

Duration: 7s
```