### PR TITLE
ECSW-2754: Add CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,5 @@
+# See https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-on-github/about-code-owners
+
+# By default, require any change be approved by a member of platformdev-release-approvers or development-compute-software
+# Later matches will take precedence over this setting.
+* @stackpath/platformdev-release-approvers @stackpath/development-compute-software


### PR DESCRIPTION
## Description

Adds `CODEOWNERS` file

The PR was initiated by the following comment: https://github.com/stackpath/admin/pull/581#pullrequestreview-1870414828
The repository has been made public, but the CODEOWNERS file hasn't been added yet.

The following two teams are set as code owners:

1. [stackpath/platformdev-release-approvers](https://github.com/orgs/stackpath/teams/platformdev-release-approvers)
2. [stackpath/development-compute-software](https://github.com/orgs/stackpath/teams/development-compute-software)